### PR TITLE
Woliveiras

### DIFF
--- a/comandos/branchs.md
+++ b/comandos/branchs.md
@@ -17,6 +17,7 @@ git checkout hash-commit -b nome-nova-branch
 ```
 
 Para encontrar o hash, você precisa rodar no terminal: `git log`.
+
 O hash é aquele número que aparece em `comit: xxxxxxx.`
 
 **3 Renomeando branches**

--- a/comandos/branchs.md
+++ b/comandos/branchs.md
@@ -1,4 +1,4 @@
-# Trabalhando com branchs
+# Trabalhando com branches
 
 **1 Criando uma nova branch**
 ```bash
@@ -16,17 +16,20 @@ git checkout --orphan nome-branch // Criando uma nova branch vazia
 git checkout hash-commit -b nome-nova-branch
 ```
 
-**3 Renomeando branchs**
+Para encontrar o hash, você precisa rodar no terminal: `git log`.
+O hash é aquele número que aparece em `comit: xxxxxxx.`
+
+**3 Renomeando branches**
 ```bash
 git branch -m nome-branch
 ```
 
-**4 Aplicando merge em branchs**
+**4 Aplicando merge em branches**
 ```bash
 git merge nome-branch // Precisa estar na branch de destino
 ```
 
-**5 Visualizando todas as branchs existentes no repositório**
+**5 Visualizando todas as branches existentes no repositório**
 ```bash
 git branch // A branch corrente será marcada por um asterisco
 ```

--- a/comandos/commits.md
+++ b/comandos/commits.md
@@ -1,6 +1,9 @@
 # Trabalhando com commits
 
 **1 Commitando arquivos**
+
+*Depois de adicionar os arquivos com git add -A, por exemplo.*
+
 ```bash
 git commit -m "Inseir um Comentário Significativo"
 ```
@@ -21,10 +24,18 @@ git commit --amend -m "mensagem-do-commit"
 git commit -m "Mensagem commit - fix ou resolve IDissue"
 ```
 
+O ID da Issue você consegue na URL da mesma. Ex.: `issues/8` - 8.
+
+Outras palavras chave que podemos usar para fechamento de Issues: `fix, fixes, fixed, close, closes, closed, resolve, resolves, resolved`
+
 **5 Revertendo ação de um commit específico**
 ```bash
 git revert commit-hash
 ```
+
+Para encontrar o hash, você precisa rodar no terminal: `git log`.
+
+O hash é aquele número que aparece em `comit: xxxxxxx.`
 
 **6 Abortando o processo de reverter commit**
 ```bash
@@ -36,14 +47,14 @@ git revert --abort
 git merge --abort
 ```
 
-**8 Acionando a merge tool**
+**8 Acionando a [mergetool](https://git-scm.com/docs/git-mergetool)**
 ```bash
-git merge tool
+git mergetool
 ```
 
 **9 Excluindo um commit local**
 ```bash
-git reset --hard numero-hash-commit
+git reset --hard hash-commit
 ```
 
 **13 Visualiza alterações específicas**

--- a/comandos/configuracoes.md
+++ b/comandos/configuracoes.md
@@ -31,7 +31,7 @@ explorer .
 
 **5 Configura nome de usuário**
 ```bash
-git config --global user.name nome-sobrenome
+git config --global user.name nome-de-usuario
 ```
 
 **6 Configura email de usuário**
@@ -44,7 +44,7 @@ git config --global user.email email@email.com.br
 git config --global core.editor nome-editor
 ```
 
-**8 Configura a merge tool (meld)**
+**8 Configura a mergetool (meld)**
 ```bash
 git config --global merge.tool meld
 ```

--- a/comandos/git-no-servidor.md
+++ b/comandos/git-no-servidor.md
@@ -14,5 +14,5 @@ git remote
 ```
 **8.4 Enviando arquivos/modificações para o servidor**
 ```bash
-git push origin master
+git push origin <branch>
 ```

--- a/comandos/guia-simplificado.md
+++ b/comandos/guia-simplificado.md
@@ -1,6 +1,6 @@
 # Guia simplificado
 
-###1 Configurações iniciais do Git Basch
+###1 Configurações iniciais do Git
 
 **Baixando e instalando o Git**
 ```bash
@@ -49,12 +49,12 @@ git log --oneline // exibe log com hash e título do commit
 
 **Enviando as modificações para o repositório remoto**
 ```bash
-git push origin master
+git push origin <branch>
 ```
 
 **Puxando alterações do repositório remoto**
 ```bash
-git pull origin master
+git pull origin <branch>
 ```
 
 ###4 Trabalhando com branchs
@@ -69,7 +69,7 @@ git checkout -b nome-branch
 git merge nome-branch // precisa estar na branch de destino
 ```
 
-**Visualizando todas as branchs existentes no repositório**
+**Visualizando todas as branches existentes no repositório**
 ```bash
 git branch
 ```

--- a/comandos/trabalhando-git-github.md
+++ b/comandos/trabalhando-git-github.md
@@ -2,7 +2,8 @@
 
 **1 Gerando uma chave SSH de autenticação no Git bash**
 ```bash
-// aplique 2 enters para confirmar "nome de arquivo" e "senha", 
+// aplique 2 enters para confirmar "nome de arquivo" e "senha"
+//(caso queira adicionar uma senha ao arquivo, aplique um enter, digite a senha e pressione enter de novo) 
 ssh-keygen
 
 // Localize a chave em "Meus Documentos"
@@ -61,7 +62,7 @@ git remote set-url origin url-repositorio
 
 **11 Enviando as modificações para o GitHub**
 ```bash
-git push origin master
+git push origin <branch>
 ```
 
 **12 Deletando branch remota**
@@ -72,14 +73,14 @@ git push origin :nome-da-branch
 
 **13 Baixando as modificações do GitHub para a sua máquina** (Se o repositório for de sua autoria)
 ```bash
-git pull origin master
+git pull origin <branch>
 ```
 
 **14 Forçando git pull** (Os arquivos que estão locais serão subscritos)
 ```bash
 git fetch --all
-git reset --hard origin/master
-git pull origin master
+git reset --hard origin/<branch>
+git pull origin <branch>
 ```
 
 **15 Mantendo o Repositório Forkado atualizado com o original**
@@ -102,5 +103,9 @@ git merge upstream/master
 
 **18 Fechar issues através de commits**
 ```bash
-git commit -m "Mensagem commit - fix issue #1"
+git commit -m "Mensagem commit - fix issue IDIssue"
 ```
+
+O ID da Issue você consegue na URL da mesma. Ex.: `issues/8` - 8.
+
+Outras palavras chave que podemos usar para fechamento de Issues: `fix, fixes, fixed, close, closes, closed, resolve, resolves, resolved`


### PR DESCRIPTION
Padronizado algumas chamadas como hash-commit que em alguns arquivos possuia nomenclatura diferente.

Corrigido de branchs para branches.
Não modifiquei o nome do arquivo branchs.md para branches.md por que você pode ter colocado o link em algum lugar, então quebraria tudo! ;D

Coloquei em alguns locais a mensagem:

Para encontrar o hash, você precisa rodar no terminal: `git log`.

O hash é aquele número que aparece em `comit: xxxxxxx.`

Para quem não sabe coletar o hash, mas acho que vai ficar repetitivo. Vou melhorar e mando novamente para você analisar se acha legal. :)

Parabéns pelo repo.
